### PR TITLE
add call for participants

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ The teams will be supported by a resident developer and the program organisers.
 ## Applications
 
 Mob programming facilitators are recruited by the organisers.
-The [call for facilitator applicatons](./facilitators.md) is open until 2024-03-24.
+The [call for facilitator applicatons](./facilitators.md) has closed on 2024-03-24.
 
 Each facilitator sets their mob's schedule and, in turn, recruits four members for their mob.
-We will publish a call for participant applications in April 2024.
+The [call for participant applications](./participants.md) is open until 2024-05-10.
 
 ## Eligibility
 
@@ -69,6 +69,7 @@ To be considered for participation, applicants must:
    - At least one programming language
  - Have basic familiarity with Nix
  - Meet the [technical requirements](#technical-requirements)
+ - Be available for a total of 160 hours of regular sessions over 13 weeks.
 
 ## Stipends
 

--- a/README.md
+++ b/README.md
@@ -93,28 +93,14 @@ You must be able to receive payments via one of:
 Remote mob programming requires being able to simultaneously share your screen, view others' screens, talk to each other, and compile software.
 This is only possible with sufficiently performant hardware, and therefore it's a condition for participation.
 
-### Processing power
-
-Be able to build the Linux kernel in under 35 minutes.
-Here's how to benchmark using Nix:
-
-```bash
-PKGS="github:NixOS/nixpkgs?tag=23.11"
-NIX_CONFIG="experimental-features = nix-command flakes"
-nix build --no-link "$PKGS#linux.inputDerivation"
-time nix build --offline --no-link --print-build-logs "$PKGS#linux"
-```
-
-To rebuild, execute the last command with an additional flag `--rebuild`.
-
 ### Video calls
 
 - Video camera
 - Headphones and reasonable-quality microphone
 - Consistently low-noise environment
+- Enough processing power for multiple concurrent video streams
 
-Please use a friend to make a test call on [Jitsi Meet](https://meet.jit.si/), including video, audio and *entire screen* sharing.
-Ask a friend whether they can see your screen and hear you well while you are running [the benchmark](#processing-power).
+Please ask a friend to make a test call on [Jitsi Meet](https://meet.jit.si/) to ensure that they can see your screen and hear you well.
 
 ### Internet connection
 

--- a/participants.md
+++ b/participants.md
@@ -1,0 +1,42 @@
+# 2024 Summer of Nix: Call for participants
+
+Apply for [Summer of Nix 2024](https://github.com/ngi-nix/summer-of-nix) to join one of four teams in making selected free and open source software (FOSS) projects work reliably on a whim using Nix and NixOS.
+
+# Requirements
+
+- Meet the [general eligibility requirements](./README.md#eligibility).
+- Profiency with at least one widely-used programming language
+- Experience with software development best practices (version control, testing, ...)
+- Bonus: Nix experience
+- Bonus: Mob programming experience
+
+# Compensation and benefits
+
+The Summer of Nix motto is **work, learn, and meet**:
+
+- You will receive a stipend:
+    - 3000 EUR for EU residents
+    - [Adjusted to purchasing power parity](./stipends.md) for residents of other countries
+- You will gain experience with Nix and open source software development
+- You will expand your professional network
+- You will get a free ticket for NixCon 2024
+- Your blog posts, talks, or public appearances related to Summer of Nix will find an audience in the Nix community
+
+# Working conditions
+
+- You will participate in 160 hours of mob programming sessions over 13 weeks, guided by mob facilitators and project organisers.
+- There will be opportunities for sharing experience and feedback.
+- Due to the nature of this project's collaboration model, your work results, including your contributions to technical discussion, will appear in publicly accessible places on the internet, such as GitHub, and remain there indefinitely.
+
+Check the [2023 Summer of Nix program updates](https://discourse.nixos.org/t/2023-summer-of-nix-program-updates/30376) for impressions of what to expect.
+
+# Application process
+
+People from anywhere in the world can apply, regardless of background.
+We strive to have a collaboration environment that is safe, constructive, friendly, and diverse.
+
+- Join the [Summer of Nix 2024 facilitator introductions](https://matrix.to/#/#son2024-facilitator-intros:matrix.org) Matrix room.
+- Facilitators will announce their schedule and other team details.
+- Message one of the facilitators with your application until 2024-05-10.
+- Facilitators will select their team members among applicants, taking geographic, cultural, and gender diversity into account.
+- You will get a reply with the result by 2023-05-13.

--- a/participants.md
+++ b/participants.md
@@ -8,6 +8,7 @@ Apply for [Summer of Nix 2024](https://github.com/ngi-nix/summer-of-nix) to join
 - Profiency with at least one widely-used programming language
 - Experience with software development best practices (version control, testing, ...)
 - Bonus: Nix experience
+- Bonus: Experience with contributing to open source software
 - Bonus: Mob programming experience
 
 # Compensation and benefits


### PR DESCRIPTION
@jackleightcap @julienmalka @janik-haag please check requirements

@janik-haag feel free to adjust technical requirements, given we'll have remote builders. I don't think we should remove them altogether, because video calls need to be fluent regardless, and one will be building things locally once in a while anyway