### PR TITLE
update stipends table

### DIFF
--- a/stipends.md
+++ b/stipends.md
@@ -1,6 +1,6 @@
 # Summer of Nix 2025 stipends
 
-Residents of EU member states receive the base stipend (see [Stipends](https://github.com/ngi-nix/summer-of-nix/tree/main?tab=readme-ov-file#stipends).)
+Residents of EU member states receive the [base stipend](./README.md#stipends).
 For residents of other countries, stipends are adjusted according to [purchasing power parity](https://en.wikipedia.org/wiki/Purchasing_power_parity) relative to the Netherlands.
 
 The following amounts are calculated using [data from Google Summer of Code](https://developers.google.com/open-source/gsoc/help/student-stipends#total_stipend_amount):

--- a/stipends.md
+++ b/stipends.md
@@ -1,203 +1,203 @@
-# Summer of Nix 2024 EUR participant stipends
+# Summer of Nix 2025 stipends
 
-Residents of EU member states receive the base stipend.
+Residents of EU member states receive the base stipend (see [Stipends](https://github.com/ngi-nix/summer-of-nix/tree/main?tab=readme-ov-file#stipends).)
 For residents of other countries, stipends are adjusted according to [purchasing power parity](https://en.wikipedia.org/wiki/Purchasing_power_parity) relative to the Netherlands.
 
-The following amounts are calculated using [data from Google Summer of Code](https://developers.google.com/open-source/gsoc/help/student-stipends#total_stipend_amount).
+The following amounts are calculated using [data from Google Summer of Code](https://developers.google.com/open-source/gsoc/help/student-stipends#total_stipend_amount):
 
-| Country | Mob facilitator | Mob member |
-|-|-|-|
-| Afghanistan | 2778 EUR | 1667 EUR |
-| Albania | 2778 EUR | 1667 EUR |
-| Algeria | 2778 EUR | 1667 EUR |
-| Andorra | 3889 EUR | 2333 EUR |
-| Angola | 2778 EUR | 1667 EUR |
-| Antigua and Barbuda | 4444 EUR | 2667 EUR |
-| Argentina | 2778 EUR | 1667 EUR |
-| Armenia | 2778 EUR | 1667 EUR |
-| Australia | 6111 EUR | 3667 EUR |
-| Austria | 5000 EUR | 3000 EUR |
-| Azerbaijan | 2778 EUR | 1667 EUR |
-| Bahamas, The | 4444 EUR | 2667 EUR |
-| Bahrain | 2778 EUR | 1667 EUR |
-| Bangladesh | 2778 EUR | 1667 EUR |
-| Barbados | 6111 EUR | 3667 EUR |
-| Belarus | 2778 EUR | 1667 EUR |
-| Belgium | 5000 EUR | 3000 EUR |
-| Belize | 3333 EUR | 2000 EUR |
-| Benin | 2778 EUR | 1667 EUR |
-| Bermuda | 6111 EUR | 3667 EUR |
-| Bhutan | 2778 EUR | 1667 EUR |
-| Bolivia | 2778 EUR | 1667 EUR |
-| Bosnia-Herzegovina | 2778 EUR | 1667 EUR |
-| Botswana | 2778 EUR | 1667 EUR |
-| Brazil | 2778 EUR | 1667 EUR |
-| Brunei Darussalam | 2778 EUR | 1667 EUR |
-| Bulgaria | 5000 EUR | 3000 EUR |
-| Burkina Faso | 2778 EUR | 1667 EUR |
-| Burundi | 2778 EUR | 1667 EUR |
-| Cabo Verde | 2778 EUR | 1667 EUR |
-| Cambodia | 2778 EUR | 1667 EUR |
-| Cameroon | 2778 EUR | 1667 EUR |
-| Canada | 5556 EUR | 3333 EUR |
-| Central African Republic | 2778 EUR | 1667 EUR |
-| Chad | 2778 EUR | 1667 EUR |
-| Chile | 3333 EUR | 2000 EUR |
-| China | 3333 EUR | 2000 EUR |
-| Colombia | 2778 EUR | 1667 EUR |
-| Comoros | 2778 EUR | 1667 EUR |
-| Congo, Dem. Rep. | 2778 EUR | 1667 EUR |
-| Congo, Rep. | 3333 EUR | 2000 EUR |
-| Costa Rica | 2778 EUR | 1667 EUR |
-| Cote d'Ivoire | 2778 EUR | 1667 EUR |
-| Croatia | 5000 EUR | 3000 EUR |
-| Cyprus | 5000 EUR | 3000 EUR |
-| Czech Republic | 5000 EUR | 3000 EUR |
-| Denmark | 5000 EUR | 3000 EUR |
-| Djibouti | 3333 EUR | 2000 EUR |
-| Dominica | 3333 EUR | 2000 EUR |
-| Dominican Republic | 2778 EUR | 1667 EUR |
-| Ecuador | 2778 EUR | 1667 EUR |
-| Egypt | 2778 EUR | 1667 EUR |
-| El Salvador | 2778 EUR | 1667 EUR |
-| Equatorial Guinea | 2778 EUR | 1667 EUR |
-| Eritrea | 2778 EUR | 1667 EUR |
-| Estonia | 5000 EUR | 3000 EUR |
-| Eswatini | 2778 EUR | 1667 EUR |
-| Ethiopia | 2778 EUR | 1667 EUR |
-| Fiji | 2778 EUR | 1667 EUR |
-| Finland | 5000 EUR | 3000 EUR |
-| France | 5000 EUR | 3000 EUR |
-| Gabon | 2778 EUR | 1667 EUR |
-| Gambia, The | 2778 EUR | 1667 EUR |
-| Georgia | 2778 EUR | 1667 EUR |
-| Germany | 5000 EUR | 3000 EUR |
-| Ghana | 2778 EUR | 1667 EUR |
-| Greece | 5000 EUR | 3000 EUR |
-| Grenada | 3333 EUR | 2000 EUR |
-| Guatemala | 2778 EUR | 1667 EUR |
-| Guinea | 2778 EUR | 1667 EUR |
-| Guinea-Bissau | 2778 EUR | 1667 EUR |
-| Guyana | 2778 EUR | 1667 EUR |
-| Haiti | 3333 EUR | 2000 EUR |
-| Honduras | 2778 EUR | 1667 EUR |
-| Hong Kong | 4444 EUR | 2667 EUR |
-| Hungary | 5000 EUR | 3000 EUR |
-| Iceland | 6111 EUR | 3667 EUR |
-| India | 2778 EUR | 1667 EUR |
-| Indonesia | 2778 EUR | 1667 EUR |
-| Iraq | 2778 EUR | 1667 EUR |
-| Ireland | 5000 EUR | 3000 EUR |
-| Israel | 6111 EUR | 3667 EUR |
-| Italy | 5000 EUR | 3000 EUR |
-| Jamaica | 2778 EUR | 1667 EUR |
-| Japan | 5000 EUR | 3000 EUR |
-| Jordan | 2778 EUR | 1667 EUR |
-| Kazakhstan | 2778 EUR | 1667 EUR |
-| Kenya | 2778 EUR | 1667 EUR |
-| Kiribati | 3889 EUR | 2333 EUR |
-| Kosovo | 2778 EUR | 1667 EUR |
-| Kuwait | 2778 EUR | 1667 EUR |
-| Kyrgyz Republic | 2778 EUR | 1667 EUR |
-| Lao PDR | 2778 EUR | 1667 EUR |
-| Latvia | 5000 EUR | 3000 EUR |
-| Lebanon | 2778 EUR | 1667 EUR |
-| Lesotho | 2778 EUR | 1667 EUR |
-| Liberia | 2778 EUR | 1667 EUR |
-| Libya | 2778 EUR | 1667 EUR |
-| Lithuania | 5000 EUR | 3000 EUR |
-| Luxembourg | 5000 EUR | 3000 EUR |
-| Macao SAR, China | 3333 EUR | 2000 EUR |
-| Madagascar | 2778 EUR | 1667 EUR |
-| Malawi | 2778 EUR | 1667 EUR |
-| Malaysia | 2778 EUR | 1667 EUR |
-| Maldives | 2778 EUR | 1667 EUR |
-| Mali | 2778 EUR | 1667 EUR |
-| Malta | 5000 EUR | 3000 EUR |
-| Marshall Islands | 5556 EUR | 3333 EUR |
-| Mauritania | 2778 EUR | 1667 EUR |
-| Mauritius | 2778 EUR | 1667 EUR |
-| Mexico | 2778 EUR | 1667 EUR |
-| Micronesia, Fed. Sts. | 5556 EUR | 3333 EUR |
-| Moldova | 2778 EUR | 1667 EUR |
-| Mongolia | 2778 EUR | 1667 EUR |
-| Montenegro | 2778 EUR | 1667 EUR |
-| Morocco | 2778 EUR | 1667 EUR |
-| Mozambique | 2778 EUR | 1667 EUR |
-| Myanmar | 2778 EUR | 1667 EUR |
-| Namibia | 2778 EUR | 1667 EUR |
-| Nepal | 2778 EUR | 1667 EUR |
-| Netherlands | 5000 EUR | 3000 EUR |
-| New Zealand | 6111 EUR | 3667 EUR |
-| Nicaragua | 2778 EUR | 1667 EUR |
-| Niger | 2778 EUR | 1667 EUR |
-| Nigeria | 2778 EUR | 1667 EUR |
-| North Macedonia | 2778 EUR | 1667 EUR |
-| Norway | 6111 EUR | 3667 EUR |
-| Oman | 2778 EUR | 1667 EUR |
-| Pakistan | 2778 EUR | 1667 EUR |
-| Palau | 5000 EUR | 3000 EUR |
-| Panama | 2778 EUR | 1667 EUR |
-| Papua New Guinea | 3889 EUR | 2333 EUR |
-| Paraguay | 2778 EUR | 1667 EUR |
-| Peru | 2778 EUR | 1667 EUR |
-| Philippines | 2778 EUR | 1667 EUR |
-| Poland | 5000 EUR | 3000 EUR |
-| Portugal | 5000 EUR | 3000 EUR |
-| Puerto Rico | 5000 EUR | 3000 EUR |
-| Qatar | 3889 EUR | 2333 EUR |
-| Romania | 5000 EUR | 3000 EUR |
-| Russian Federation | 2778 EUR | 1667 EUR |
-| Rwanda | 2778 EUR | 1667 EUR |
-| Samoa | 3333 EUR | 2000 EUR |
-| Sao Tome and Principe | 3333 EUR | 2000 EUR |
-| Saudi Arabia | 2778 EUR | 1667 EUR |
-| Senegal | 2778 EUR | 1667 EUR |
-| Serbia | 2778 EUR | 1667 EUR |
-| Seychelles | 2778 EUR | 1667 EUR |
-| Sierra Leone | 2778 EUR | 1667 EUR |
-| Singapore | 3333 EUR | 2000 EUR |
-| Slovak Republic | 3333 EUR | 2000 EUR |
-| Slovenia | 5000 EUR | 3000 EUR |
-| Solomon Islands | 5000 EUR | 3000 EUR |
-| Somalia | 2778 EUR | 1667 EUR |
-| South Africa | 2778 EUR | 1667 EUR |
-| South Korea | 3889 EUR | 2333 EUR |
-| South Sudan | 5000 EUR | 3000 EUR |
-| Spain | 5000 EUR | 3000 EUR |
-| Sri Lanka | 2778 EUR | 1667 EUR |
-| St. Kitts and Nevis | 3889 EUR | 2333 EUR |
-| St. Lucia | 3889 EUR | 2333 EUR |
-| St. Vincent and the Grenadines | 3333 EUR | 2000 EUR |
-| Sudan | 2778 EUR | 1667 EUR |
-| Suriname | 2778 EUR | 1667 EUR |
-| Swaziland | 2778 EUR | 1667 EUR |
-| Sweden | 5000 EUR | 3000 EUR |
-| Switzerland | 6111 EUR | 3667 EUR |
-| Taiwan | 2778 EUR | 1667 EUR |
-| Tajikistan | 2778 EUR | 1667 EUR |
-| Tanzania | 2778 EUR | 1667 EUR |
-| Thailand | 2778 EUR | 1667 EUR |
-| Timor-Leste | 2778 EUR | 1667 EUR |
-| Togo | 2778 EUR | 1667 EUR |
-| Tonga | 3889 EUR | 2333 EUR |
-| Trinidad and Tobago | 3333 EUR | 2000 EUR |
-| Tunisia | 2778 EUR | 1667 EUR |
-| Turkey | 2778 EUR | 1667 EUR |
-| Turkmenistan | 2778 EUR | 1667 EUR |
-| Turks and Caicos Islands | 5556 EUR | 3333 EUR |
-| Tuvalu | 5556 EUR | 3333 EUR |
-| Uganda | 2778 EUR | 1667 EUR |
-| Ukraine | 2778 EUR | 1667 EUR |
-| United Arab Emirates | 2778 EUR | 1667 EUR |
-| United Kingdom | 5000 EUR | 3000 EUR |
-| United States | 5556 EUR | 3333 EUR |
-| Uruguay | 3889 EUR | 2333 EUR |
-| Uzbekistan | 2778 EUR | 1667 EUR |
-| Vanuatu | 5556 EUR | 3333 EUR |
-| Venezuela | 3333 EUR | 2000 EUR |
-| Vietnam | 2778 EUR | 1667 EUR |
-| West Bank and Gaza | 3333 EUR | 2000 EUR |
-| Yemen, Rep. | 2778 EUR | 1667 EUR |
-| Zambia | 2778 EUR | 1667 EUR |
-| Zimbabwe | 3889 EUR | 2333 EUR |
+| Country | Mentor [EUR] | Participant [EUR] |
+|---------|--------------|-------------------|
+| Afghanistan | 2778 | 1667 |
+| Albania | 2778 | 1667 |
+| Algeria | 2778 | 1667 |
+| Andorra | 3889 | 2333 |
+| Angola | 2778 | 1667 |
+| Antigua and Barbuda | 4444 | 2667 |
+| Argentina | 2778 | 1667 |
+| Armenia | 2778 | 1667 |
+| Australia | 6111 | 3667 |
+| Austria | 5000 | 3000 |
+| Azerbaijan | 2778 | 1667 |
+| Bahamas, The | 4444 | 2667 |
+| Bahrain | 2778 | 1667 |
+| Bangladesh | 2778 | 1667 |
+| Barbados | 6111 | 3667 |
+| Belarus | 2778 | 1667 |
+| Belgium | 5000 | 3000 |
+| Belize | 3333 | 2000 |
+| Benin | 2778 | 1667 |
+| Bermuda | 6111 | 3667 |
+| Bhutan | 2778 | 1667 |
+| Bolivia | 2778 | 1667 |
+| Bosnia-Herzegovina | 2778 | 1667 |
+| Botswana | 2778 | 1667 |
+| Brazil | 2778 | 1667 |
+| Brunei Darussalam | 2778 | 1667 |
+| Bulgaria | 5000 | 3000 |
+| Burkina Faso | 2778 | 1667 |
+| Burundi | 2778 | 1667 |
+| Cabo Verde | 2778 | 1667 |
+| Cambodia | 2778 | 1667 |
+| Cameroon | 2778 | 1667 |
+| Canada | 5556 | 3333 |
+| Central African Republic | 2778 | 1667 |
+| Chad | 2778 | 1667 |
+| Chile | 3333 | 2000 |
+| China | 3333 | 2000 |
+| Colombia | 2778 | 1667 |
+| Comoros | 2778 | 1667 |
+| Congo, Dem. Rep. | 2778 | 1667 |
+| Congo, Rep. | 3333 | 2000 |
+| Costa Rica | 2778 | 1667 |
+| Cote d'Ivoire | 2778 | 1667 |
+| Croatia | 5000 | 3000 |
+| Cyprus | 5000 | 3000 |
+| Czech Republic | 5000 | 3000 |
+| Denmark | 5000 | 3000 |
+| Djibouti | 3333 | 2000 |
+| Dominica | 3333 | 2000 |
+| Dominican Republic | 2778 | 1667 |
+| Ecuador | 2778 | 1667 |
+| Egypt | 2778 | 1667 |
+| El Salvador | 2778 | 1667 |
+| Equatorial Guinea | 2778 | 1667 |
+| Eritrea | 2778 | 1667 |
+| Estonia | 5000 | 3000 |
+| Eswatini | 2778 | 1667 |
+| Ethiopia | 2778 | 1667 |
+| Fiji | 2778 | 1667 |
+| Finland | 5000 | 3000 |
+| France | 5000 | 3000 |
+| Gabon | 2778 | 1667 |
+| Gambia, The | 2778 | 1667 |
+| Georgia | 2778 | 1667 |
+| Germany | 5000 | 3000 |
+| Ghana | 2778 | 1667 |
+| Greece | 5000 | 3000 |
+| Grenada | 3333 | 2000 |
+| Guatemala | 2778 | 1667 |
+| Guinea | 2778 | 1667 |
+| Guinea-Bissau | 2778 | 1667 |
+| Guyana | 2778 | 1667 |
+| Haiti | 3333 | 2000 |
+| Honduras | 2778 | 1667 |
+| Hong Kong | 4444 | 2667 |
+| Hungary | 5000 | 3000 |
+| Iceland | 6111 | 3667 |
+| India | 2778 | 1667 |
+| Indonesia | 2778 | 1667 |
+| Iraq | 2778 | 1667 |
+| Ireland | 5000 | 3000 |
+| Israel | 6111 | 3667 |
+| Italy | 5000 | 3000 |
+| Jamaica | 2778 | 1667 |
+| Japan | 5000 | 3000 |
+| Jordan | 2778 | 1667 |
+| Kazakhstan | 2778 | 1667 |
+| Kenya | 2778 | 1667 |
+| Kiribati | 3889 | 2333 |
+| Kosovo | 2778 | 1667 |
+| Kuwait | 2778 | 1667 |
+| Kyrgyz Republic | 2778 | 1667 |
+| Lao PDR | 2778 | 1667 |
+| Latvia | 5000 | 3000 |
+| Lebanon | 2778 | 1667 |
+| Lesotho | 2778 | 1667 |
+| Liberia | 2778 | 1667 |
+| Libya | 2778 | 1667 |
+| Lithuania | 5000 | 3000 |
+| Luxembourg | 5000 | 3000 |
+| Macao SAR, China | 3333 | 2000 |
+| Madagascar | 2778 | 1667 |
+| Malawi | 2778 | 1667 |
+| Malaysia | 2778 | 1667 |
+| Maldives | 2778 | 1667 |
+| Mali | 2778 | 1667 |
+| Malta | 5000 | 3000 |
+| Marshall Islands | 5556 | 3333 |
+| Mauritania | 2778 | 1667 |
+| Mauritius | 2778 | 1667 |
+| Mexico | 2778 | 1667 |
+| Micronesia, Fed. Sts. | 5556 | 3333 |
+| Moldova | 2778 | 1667 |
+| Mongolia | 2778 | 1667 |
+| Montenegro | 2778 | 1667 |
+| Morocco | 2778 | 1667 |
+| Mozambique | 2778 | 1667 |
+| Myanmar | 2778 | 1667 |
+| Namibia | 2778 | 1667 |
+| Nepal | 2778 | 1667 |
+| Netherlands | 5000 | 3000 |
+| New Zealand | 6111 | 3667 |
+| Nicaragua | 2778 | 1667 |
+| Niger | 2778 | 1667 |
+| Nigeria | 2778 | 1667 |
+| North Macedonia | 2778 | 1667 |
+| Norway | 6111 | 3667 |
+| Oman | 2778 | 1667 |
+| Pakistan | 2778 | 1667 |
+| Palau | 5000 | 3000 |
+| Panama | 2778 | 1667 |
+| Papua New Guinea | 3889 | 2333 |
+| Paraguay | 2778 | 1667 |
+| Peru | 2778 | 1667 |
+| Philippines | 2778 | 1667 |
+| Poland | 5000 | 3000 |
+| Portugal | 5000 | 3000 |
+| Puerto Rico | 5000 | 3000 |
+| Qatar | 3889 | 2333 |
+| Romania | 5000 | 3000 |
+| Russian Federation | 2778 | 1667 |
+| Rwanda | 2778 | 1667 |
+| Samoa | 3333 | 2000 |
+| Sao Tome and Principe | 3333 | 2000 |
+| Saudi Arabia | 2778 | 1667 |
+| Senegal | 2778 | 1667 |
+| Serbia | 2778 | 1667 |
+| Seychelles | 2778 | 1667 |
+| Sierra Leone | 2778 | 1667 |
+| Singapore | 3333 | 2000 |
+| Slovak Republic | 5000 | 3000 |
+| Slovenia | 5000 | 3000 |
+| Solomon Islands | 5000 | 3000 |
+| Somalia | 2778 | 1667 |
+| South Africa | 2778 | 1667 |
+| South Korea | 3889 | 2333 |
+| South Sudan | 5000 | 3000 |
+| Spain | 5000 | 3000 |
+| Sri Lanka | 2778 | 1667 |
+| St. Kitts and Nevis | 3889 | 2333 |
+| St. Lucia | 3889 | 2333 |
+| St. Vincent and the Grenadines | 3333 | 2000 |
+| Sudan | 2778 | 1667 |
+| Suriname | 2778 | 1667 |
+| Swaziland | 2778 | 1667 |
+| Sweden | 5000 | 3000 |
+| Switzerland | 6111 | 3667 |
+| Taiwan | 2778 | 1667 |
+| Tajikistan | 2778 | 1667 |
+| Tanzania | 2778 | 1667 |
+| Thailand | 2778 | 1667 |
+| Timor-Leste | 2778 | 1667 |
+| Togo | 2778 | 1667 |
+| Tonga | 3889 | 2333 |
+| Trinidad and Tobago | 3333 | 2000 |
+| Tunisia | 2778 | 1667 |
+| Turkey | 2778 | 1667 |
+| Turkmenistan | 2778 | 1667 |
+| Turks and Caicos Islands | 5556 | 3333 |
+| Tuvalu | 5556 | 3333 |
+| Uganda | 2778 | 1667 |
+| Ukraine | 2778 | 1667 |
+| United Arab Emirates | 2778 | 1667 |
+| United Kingdom | 5556 | 3333 |
+| United States | 5556 | 3333 |
+| Uruguay | 3889 | 2333 |
+| Uzbekistan | 2778 | 1667 |
+| Vanuatu | 5556 | 3333 |
+| Venezuela | 3333 | 2000 |
+| Vietnam | 2778 | 1667 |
+| West Bank and Gaza | 3333 | 2000 |
+| Yemen, Rep. | 2778 | 1667 |
+| Zambia | 2778 | 1667 |
+| Zimbabwe | 3889 | 2333 |


### PR DESCRIPTION
- Simplified headers
- Found an error in Slovakia's and UK's entries

There is no diff from the [2024](https://web.archive.org/web/20250122152206/https://developers.google.com/open-source/gsoc/help/student-stipends) and [2025](https://web.archive.org/web/20250129032442/https://developers.google.com/open-source/gsoc/help/student-stipends#total_stipend_amount) stipend tables.

Closes: https://github.com/ngi-nix/admin/issues/50