### PR TITLE
Get author emails for a message

### DIFF
--- a/admin/pyproject.toml
+++ b/admin/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
   "githubkit",
   "pydantic",
   "tqdm",
+  "questionary>=2.1.0",
 ]
 
 [dependency-groups]

--- a/admin/scripts/common/models/notion.py
+++ b/admin/scripts/common/models/notion.py
@@ -27,3 +27,8 @@ class Overview(BaseModel):
 class Project(BaseModel):
     name: str = ""
     subgrants: List[str] = []
+
+
+class AuthorMessages(BaseModel):
+    message: str
+    contacted: str

--- a/admin/scripts/common/utils.py
+++ b/admin/scripts/common/utils.py
@@ -70,7 +70,7 @@ def unzip_notion_export(zip_file_path) -> Optional[str | None]:
     try:
         with zipfile.ZipFile(zip_file_path, "r") as zip_ref:
             zip_ref.extractall(tmp_dir)
-        return tmp_dir
+        return f"{tmp_dir}/Private & Shared/"
     except Exception:
         return None
 

--- a/admin/scripts/common/utils.py
+++ b/admin/scripts/common/utils.py
@@ -85,6 +85,6 @@ def get_notion_projects(zip_file_path) -> Optional[str | None]:
     for file in os.listdir(unzipped_dir):
         if file.endswith("_all.csv") or not file.endswith(".csv"):
             continue
-        if file.startswith("Projects"):
-            return os.path.join(unzipped_dir, file)
+
+        return os.path.join(unzipped_dir, file)
     return None

--- a/admin/scripts/extract_project_metadata.py
+++ b/admin/scripts/extract_project_metadata.py
@@ -4,30 +4,31 @@ import argparse
 import json
 import logging
 import os
+import random
 import sys
+from contextlib import contextmanager
 
 import ijson
+import pandas as pd
+import questionary
 from common.models.dashboard import Fund
-from common.models.notion import Overview, Subgrant
+from common.models.notion import AuthorMessages, Overview, Subgrant
 from common.utils import dir_path, get_notion_projects, remove_urls, zip_file_type
 from pydantic import ValidationError
 from tqdm import tqdm
 
 # fmt: off
 choices = {
-    "default": lambda subgrants: {
+    "default": lambda inputs: {
         s.name: s.model_dump()
-        for s in subgrants
+        for s in inputs["subgrants"]
     },
-    "emails": lambda subgrants: sorted(
-        set(s.contact.email for s in subgrants),
-        key=lambda email: email.split("@")[1]
-    ),
-    "overview": lambda subgrants: {
+    "emails": lambda inputs: get_new_contacts_for_message(**inputs),
+    "overview": lambda inputs: {
         o.name: o.model_dump()
         for o in [
             Overview(name=s.name, websites=s.websites, summary=s.summary)
-            for s in subgrants
+            for s in inputs["subgrants"]
         ]
     },
 }
@@ -82,6 +83,65 @@ class Cli:
         self.args = self.parser.parse_args()
 
 
+@contextmanager
+def redirect_stdout(tmp_stream):
+    """Temporarily redirect sys.stdout to a different output stream"""
+    original_stdout = sys.stdout
+    sys.stdout = tmp_stream
+    try:
+        yield
+    finally:
+        sys.stdout = original_stdout
+
+
+def get_new_contacts_for_message(
+    logger: logging.Logger, args: argparse.Namespace, subgrants: list[Subgrant]
+):
+    """
+    Prompts users to choose a message, then determines which NGI project authors
+    have not been contacted for that message, yet
+    """
+    messages = get_notion_projects(args.author_messages_zip)
+
+    if messages is None:
+        logger.error(f"Failed to extract {args.author_messages_zip}")
+        exit()
+
+    messages = pd.read_csv(messages, usecols=["Name", "Already contacted"])
+    messages["Already contacted"] = messages["Already contacted"].apply(
+        lambda x: remove_urls(x) if pd.notna(x) else ""
+    )
+    messages = {
+        m["Name"]: AuthorMessages(message=m["Name"], contacted=m["Already contacted"])
+        for m in messages.to_dict(orient="records")
+    }
+
+    # Prompt users through stderr since stdout is already used for the result
+    with redirect_stdout(sys.stderr):
+        response: str | None = questionary.select(
+            "What email message do you need?",
+            choices=[n.message for n in messages.values()],
+        ).ask()
+
+    if response is None:
+        exit()
+
+    new_contacts: list[str] = []
+    for c in subgrants:
+        if c.contact.name in messages[response].contacted:
+            continue
+        new_contacts.append(f'"{c.contact.name}","<{c.contact.email}>"')
+    new_contacts = sorted(set(new_contacts))
+
+    if args.samples is not None:
+        new_contacts = random.sample(new_contacts, args.samples)
+
+    print("Name,Email")
+    for c in new_contacts:
+        print(c)
+    exit()
+
+
 def main():
     args = Cli().args
 
@@ -127,7 +187,9 @@ def main():
         except ValidationError as e:
             logger.error(e)
 
-    content = choices[args.preset](subgrants)
+    content = choices[args.preset](
+        {"logger": logger, "args": args, "subgrants": subgrants}
+    )
 
     json.dump(content, sys.stdout, indent=2)
 

--- a/admin/scripts/extract_project_metadata.py
+++ b/admin/scripts/extract_project_metadata.py
@@ -6,6 +6,7 @@ import logging
 import os
 import random
 import sys
+import textwrap
 from contextlib import contextmanager
 
 import ijson
@@ -38,9 +39,20 @@ choices = {
 class Cli:
     def __init__(self) -> None:
         self.parser = argparse.ArgumentParser(
-            description="""
+            description=textwrap.dedent(f"""\
             Extract medatata from the exported NLnet grant database
-            """
+
+            Examples:
+            # Extract metadata
+            {sys.argv[0]} <NLNET-METADATA-DIRECTORY> > metadata.json
+
+            # Get the list of project author emails for a certain message
+            {sys.argv[0]} <NLNET-METADATA-DIRECTORY> <MESSAGES-ZIP> -p emails > emails.csv
+
+            ---
+
+            """),
+            formatter_class=argparse.RawTextHelpFormatter,
         )
 
         self.parser.add_argument(

--- a/admin/scripts/extract_project_metadata.py
+++ b/admin/scripts/extract_project_metadata.py
@@ -138,17 +138,19 @@ def get_new_contacts_for_message(
     if response is None:
         exit()
 
+    # Output data to stdout
+    print("Name,Email,Contacted for")  # CSV header
+
     new_contacts: list[str] = []
     for c in subgrants:
         if c.contact.name in messages[response].contacted:
             continue
-        new_contacts.append(f'"{c.contact.name}","<{c.contact.email}>"')
+        new_contacts.append(f'"{c.contact.name}","<{c.contact.email}>","{response}"')
     new_contacts = sorted(set(new_contacts))
 
     if args.samples is not None:
         new_contacts = random.sample(new_contacts, args.samples)
 
-    print("Name,Email")
     for c in new_contacts:
         print(c)
     exit()

--- a/admin/scripts/extract_project_metadata.py
+++ b/admin/scripts/extract_project_metadata.py
@@ -76,7 +76,7 @@ class Cli:
 
         self.contacts_group = self.parser.add_argument_group("Author Contacts (email)")
         self.contacts_group.add_argument(
-            "author_messages_zip",
+            "messages_zip",
             nargs="?",
             type=zip_file_type,
             help="ZIP file containing author messages from Notion",
@@ -113,10 +113,10 @@ def get_new_contacts_for_message(
     Prompts users to choose a message, then determines which NGI project authors
     have not been contacted for that message, yet
     """
-    messages = get_notion_projects(args.author_messages_zip)
+    messages = get_notion_projects(args.messages_zip)
 
     if messages is None:
-        logger.error(f"Failed to extract {args.author_messages_zip}")
+        logger.error(f"Failed to extract {args.messages_zip}")
         exit()
 
     messages = pd.read_csv(messages, usecols=["Name", "Already contacted"])
@@ -161,7 +161,7 @@ def main():
     logging_level = logging.DEBUG if args.debug else logging.WARNING
     logging.basicConfig(level=logging_level)
 
-    if args.preset == "emails" and args.author_messages_zip is None:
+    if args.preset == "emails" and args.messages_zip is None:
         logger.error(
             "Please provide the author messages zip file when choosing the 'emails' preset."
         )

--- a/admin/scripts/extract_project_metadata.py
+++ b/admin/scripts/extract_project_metadata.py
@@ -39,18 +39,30 @@ choices = {
 class Cli:
     def __init__(self) -> None:
         self.parser = argparse.ArgumentParser(
-            description=textwrap.dedent(f"""\
-            Extract medatata from the exported NLnet grant database
+            description="Extract medatata from the exported NLnet grant database",
+            epilog=textwrap.dedent(f"""
+            USAGE:
 
-            Examples:
+            1. Download projects metadata from NLnet dashboard:
+
+            - Go the the [NLnet dashboard](https://dashboard.nlnet.nl) and enter your credentials
+            - Go to each grant page, append `?json=true` to the URL, and download the file
+            - Put all downloaded files in a single directory (<NLNET-METADATA-DIRECTORY>)
+
+            2. If you want to contact project authors, get the messages file from Notion:
+
+            - Navigate to [Messages](https://www.notion.so/nixos-foundation/19e59d49e1be8056ad71e5fc4a31b83e?v=19e59d49e1be809ea5dc000c05bcefa5&pvs=4)
+            - If you can't access the page, you should request permissions
+            - Click on the top-right menu and export as a csv, choosing the default options
+            - Save the ZIP file to your filesystem (<MESSAGES-ZIP>)
+
+            EXAMPLES:
+
             # Extract metadata
-            {sys.argv[0]} <NLNET-METADATA-DIRECTORY> > metadata.json
+            {os.path.basename(sys.argv[0])} <NLNET-METADATA-DIRECTORY> > metadata.json
 
             # Get the list of project author emails for a certain message
-            {sys.argv[0]} <NLNET-METADATA-DIRECTORY> <MESSAGES-ZIP> -p emails > emails.csv
-
-            ---
-
+            {os.path.basename(sys.argv[0])} <NLNET-METADATA-DIRECTORY> <MESSAGES-ZIP> -p emails > emails.csv
             """),
             formatter_class=argparse.RawTextHelpFormatter,
         )

--- a/admin/uv.lock
+++ b/admin/uv.lock
@@ -34,6 +34,7 @@ dependencies = [
     { name = "pandas" },
     { name = "pandas-stubs" },
     { name = "pydantic" },
+    { name = "questionary" },
     { name = "tqdm" },
 ]
 
@@ -49,6 +50,7 @@ requires-dist = [
     { name = "pandas" },
     { name = "pandas-stubs" },
     { name = "pydantic" },
+    { name = "questionary", specifier = ">=2.1.0" },
     { name = "tqdm" },
 ]
 
@@ -279,6 +281,18 @@ wheels = [
 ]
 
 [[package]]
+name = "prompt-toolkit"
+version = "3.0.50"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/e1/bd15cb8ffdcfeeb2bdc215de3c3cffca11408d829e4b8416dcfe71ba8854/prompt_toolkit-3.0.50.tar.gz", hash = "sha256:544748f3860a2623ca5cd6d2795e7a14f3d0e1c3c9728359013f79877fc89bab", size = 429087 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/ea/d836f008d33151c7a1f62caf3d8dd782e4d15f6a43897f64480c2b8de2ad/prompt_toolkit-3.0.50-py3-none-any.whl", hash = "sha256:9b6427eb19e479d98acff65196a307c555eb567989e6d88ebbb1b509d9779198", size = 387816 },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.10.6"
 source = { registry = "https://pypi.org/simple" }
@@ -368,6 +382,18 @@ wheels = [
 ]
 
 [[package]]
+name = "questionary"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "prompt-toolkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/b8/d16eb579277f3de9e56e5ad25280fab52fc5774117fb70362e8c2e016559/questionary-2.1.0.tar.gz", hash = "sha256:6302cdd645b19667d8f6e6634774e9538bfcd1aad9be287e743d96cacaf95587", size = 26775 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/3f/11dd4cd4f39e05128bfd20138faea57bec56f9ffba6185d276e3107ba5b2/questionary-2.1.0-py3-none-any.whl", hash = "sha256:44174d237b68bc828e4878c763a9ad6790ee61990e0ae72927694ead57bab8ec", size = 36747 },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -422,4 +448,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/0f/fa4723f22942480be4ca9527bbde8d43f6c3f2fe8412f00e7f5f6746bc8b/tzdata-2025.1.tar.gz", hash = "sha256:24894909e88cdb28bd1636c6887801df64cb485bd593f2fd83ef29075a81d694", size = 194950 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/dd/84f10e23edd882c6f968c21c2434fe67bd4a528967067515feca9e611e5e/tzdata-2025.1-py2.py3-none-any.whl", hash = "sha256:7e127113816800496f027041c570f50bcd464a020098a3b6b199517772303639", size = 346762 },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.2.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166 },
 ]


### PR DESCRIPTION
Modifies the data-extraction script to prompt users to choose a [message](https://www.notion.so/nixos-foundation/19e59d49e1be8056ad71e5fc4a31b83e?v=19e59d49e1be809ea5dc000c05bcefa5), determines which NGI project authors to contact for that message, and outputs a CSV file that can be imported in the [Author email message tracker](https://www.notion.so/nixos-foundation/19e59d49e1be803e871dcc6cb2b36470?v=19e59d49e1be80799bd8000c2efea262) table.

Usage example are included in `extract-project-metadata --help` message.

Related: https://github.com/ngi-nix/summer-of-nix/issues/156