### PR TITLE
Init script to extract survey responses

### DIFF
--- a/admin/scripts/common/models/__init__.py
+++ b/admin/scripts/common/models/__init__.py
@@ -73,12 +73,6 @@ class Form(BaseModel):
                 return True
             return False
 
-        @field_validator(question_alias_mapping["q3"], mode="before")
-        def map_duration(cls, value: str) -> str:
-            if value.replace(".", "", 1).isdigit():
-                return f"{value}h per week"
-            return value
-
         @field_validator(question_alias_mapping["q6"], mode="before")
         def map_contributors(cls, value: str) -> float | None:
             if value.replace(".", "", 1).isdigit():

--- a/admin/scripts/common/models/__init__.py
+++ b/admin/scripts/common/models/__init__.py
@@ -75,8 +75,8 @@ class NixFamiliarity(str, Enum):
 alias_mapping = {
     "q1": "project_name",
     "q2": "author_role",
-    "q3": "build_failure_duration",
-    "q4": "automatic_dependency_update",
+    "q3": "duration_build_failure",
+    "q4": "dependency_update_automatic",
     "q5": "dependency_update_frequency",
     "q6": "contributors",
     "q7": "devenv_setup_time",
@@ -100,8 +100,8 @@ alias_mapping = {
     "q22": "author_preferred_channels",
     "q23": "author_contact",
     #
-    "q24": "structured_data_provided",
-    "q25": "reminder",
+    "q24": "survey_with_structured_data",
+    "q25": "survey_reminder",
     # artefacts
     "q26": "libraries_exist",
     "q27": "documentation_libraries",
@@ -154,12 +154,12 @@ class Form(BaseModel):
         author_name: str = Field(alias="_name")
         author_role: list[AuthorRole]
 
-        build_failure_duration: str
-        automatic_dependency_update: Choice
+        duration_build_failure: str
+        dependency_update_automatic: Choice
         dependency_update_frequency: UpdateFrequency
         devenv_setup_time: DevenvSetupTimes
         contributors: int | None
-        reminder: Optional[ChoiceReminder] = Field(default=None)
+        survey_reminder: Optional[ChoiceReminder] = Field(default=None)
 
         # Nix
         nix_familiarity: NixFamiliarity
@@ -169,7 +169,7 @@ class Form(BaseModel):
         nix_maintain: ChoiceAgreement
         nix_discover: ChoiceAgreement
 
-        structured_data_provided: bool = Field(default=False)
+        survey_with_structured_data: bool = Field(default=False)
         extensions_exist: bool = Field(default=False)
 
     questions: dict[str, str]
@@ -222,8 +222,8 @@ def project_from_response(
         "contributors": resp.contributors,
         "infra": {
             "ci_cd": {
-                "build_failure_duration": resp.build_failure_duration,
-                "dependency_update": resp.automatic_dependency_update,
+                "build_failure_duration": resp.duration_build_failure,
+                "dependency_update": resp.dependency_update_automatic,
                 "with_nix": resp.nix_ci_cd,
             },
             "devenv": {

--- a/admin/scripts/common/models/__init__.py
+++ b/admin/scripts/common/models/__init__.py
@@ -159,14 +159,16 @@ class Form(BaseModel):
 
 
 class Project(BaseModel):
-    class Author(BaseModel):
-        class ContactInfo(BaseModel):
-            preferred_channels: list[str]
-            info: str
+    class Metadata(BaseModel):
+        class Author(BaseModel):
+            name: str
+            role: list[AuthorRole]
+            contact_channels: list[str]
+            contact: str
 
-        name: str
-        role: list[AuthorRole]
-        contact: ContactInfo
+        repository: str
+        contributors: int
+        author: Author
 
     class Infrastructure(BaseModel):
         class CI_CD(BaseModel):
@@ -189,8 +191,7 @@ class Project(BaseModel):
         available_for_pairing: Choice2
 
     name: str
-    author: Author
-    contributors: int
+    meta: Metadata
     infra: Infrastructure
     nix: Nix
 
@@ -203,15 +204,16 @@ def project_from_response(
 
     project = Project(
         name=resp.project_name,
-        author=Project.Author(
-            name=resp.author_name,
-            role=resp.author_role,
-            contact=Project.Author.ContactInfo(
-                preferred_channels=resp.author_preferred_channels,
-                info=resp.author_contact,
+        meta=Project.Metadata(
+            repository=resp.repository,
+            contributors=resp.contributors,
+            author=Project.Metadata.Author(
+                name=resp.author_name,
+                role=resp.author_role,
+                contact_channels=resp.author_preferred_channels,
+                contact=resp.author_contact,
             ),
         ),
-        contributors=resp.contributors,
         infra=Project.Infrastructure(
             ci_cd=Project.Infrastructure.CI_CD(
                 build_failure_duration=resp.duration_build_failure,

--- a/admin/scripts/common/models/__init__.py
+++ b/admin/scripts/common/models/__init__.py
@@ -126,7 +126,7 @@ class Form(BaseModel):
 
 class Project(BaseModel):
     class Author(BaseModel):
-        author_name: str
+        name: str
         role: list[AuthorRole]
 
     class Infrastructure(BaseModel):
@@ -155,18 +155,26 @@ def project_from_response(
     if resp.contributors is None:
         return (None, "contributors")
 
-    project = Project(
-        name=resp.project_name,
-        author=Project.Author(author_name=resp.author_name, role=resp.author_role),
-        contributors=resp.contributors,
-        infra=Project.Infrastructure(
-            ci_cd=Project.Infrastructure.CI_CD(
-                build_failure_duration=resp.build_failure_duration,
-                dependency_update=resp.automatic_dependency_update,
-            ),
-            devenv_setup_time=resp.devenv_setup_time,
-        ),
-        nix=Project.Nix(familiarity=resp.nix_familiarity, has_dev_env=resp.nix_dev_env),
-    )
+    project_dict = {
+        "name": resp.project_name,
+        "author": {
+            "name": resp.author_name,
+            "role": resp.author_role,
+        },
+        "contributors": resp.contributors,
+        "infra": {
+            "ci_cd": {
+                "build_failure_duration": resp.build_failure_duration,
+                "dependency_update": resp.automatic_dependency_update,
+            },
+            "devenv_setup_time": resp.devenv_setup_time,
+        },
+        "nix": {
+            "familiarity": resp.nix_familiarity,
+            "has_dev_env": resp.nix_dev_env,
+        },
+    }
+
+    project = Project.model_validate(project_dict)
 
     return (project, "")

--- a/admin/scripts/common/models/__init__.py
+++ b/admin/scripts/common/models/__init__.py
@@ -160,8 +160,13 @@ class Form(BaseModel):
 
 class Project(BaseModel):
     class Author(BaseModel):
+        class ContactInfo(BaseModel):
+            preferred_channels: list[str]
+            info: str
+
         name: str
         role: list[AuthorRole]
+        contact: ContactInfo
 
     class Infrastructure(BaseModel):
         class CI_CD(BaseModel):
@@ -181,6 +186,7 @@ class Project(BaseModel):
         can_ease_onboarding: ChoiceAgreement
         can_help_maintainability: ChoiceAgreement
         can_help_discoverability: ChoiceAgreement
+        available_for_pairing: Choice2
 
     name: str
     author: Author
@@ -200,6 +206,10 @@ def project_from_response(
         "author": {
             "name": resp.author_name,
             "role": resp.author_role,
+            "contact": {
+                "preferred_channels": resp.author_preferred_channels,
+                "info": resp.author_contact,
+            },
         },
         "contributors": resp.contributors,
         "infra": {
@@ -218,6 +228,7 @@ def project_from_response(
             "can_ease_onboarding": resp.nix_onboard,
             "can_help_maintainability": resp.nix_maintain,
             "can_help_discoverability": resp.nix_discover,
+            "available_for_pairing": resp.nix_pairing,
         },
     }
 

--- a/admin/scripts/common/models/__init__.py
+++ b/admin/scripts/common/models/__init__.py
@@ -197,21 +197,32 @@ class Project(BaseModel):
 
     class Infrastructure(BaseModel):
         class CI_CD(BaseModel):
-            build_failure_duration: str
+            build_failure_hours_per_week: str
             dependency_update: str
+            dependency_update_frequency: str
             with_nix: str
 
         class DevEnv(BaseModel):
             setup_time: str
             with_nix: str
 
+        dependency_management: str
+        framework: str
         ci_cd: CI_CD
         devenv: DevEnv
 
     class Nix(BaseModel):
-        can_ease_onboarding: str
-        can_help_maintainability: str
-        can_help_discoverability: str
+        class AuthorResponses(BaseModel):
+            can_ease_onboarding: str
+            can_help_maintainability: str
+            can_help_discoverability: str
+            can_help_self_hosting: str
+            can_ease_installation: str
+            can_increase_adoption: str
+            can_increase_user_retention: str
+            other_uses: str
+
+        author_responses: AuthorResponses
 
     name: str
     meta: Metadata
@@ -246,9 +257,12 @@ def project_from_response(
             expected_longevity=resp.duration_future_maintenance,
         ),
         infra=Project.Infrastructure(
+            dependency_management=resp.dependency_management,
+            framework=resp.project_framework,
             ci_cd=Project.Infrastructure.CI_CD(
-                build_failure_duration=resp.duration_build_failure,
+                build_failure_hours_per_week=resp.duration_build_failure,
                 dependency_update=resp.dependency_update_automatic,
+                dependency_update_frequency=resp.dependency_update_frequency,
                 with_nix=resp.nix_ci_cd,
             ),
             devenv=Project.Infrastructure.DevEnv(
@@ -257,9 +271,16 @@ def project_from_response(
             ),
         ),
         nix=Project.Nix(
-            can_ease_onboarding=resp.nix_onboard,
-            can_help_maintainability=resp.nix_maintain,
-            can_help_discoverability=resp.nix_discover,
+            author_responses=Project.Nix.AuthorResponses(
+                can_ease_onboarding=resp.nix_onboard,
+                can_help_maintainability=resp.nix_maintain,
+                can_help_discoverability=resp.nix_discover,
+                can_help_self_hosting=resp.nix_self_host,
+                can_ease_installation=resp.nix_installation,
+                can_increase_adoption=resp.nix_adoption,
+                can_increase_user_retention=resp.nix_retention,
+                other_uses=resp.nix_other_uses,
+            )
         ),
     )
 

--- a/admin/scripts/common/models/__init__.py
+++ b/admin/scripts/common/models/__init__.py
@@ -135,12 +135,15 @@ class Project(BaseModel):
             dependency_update: str
             # with_nix: bool
 
+        class DevEnv(BaseModel):
+            setup_time: str
+            with_nix: Choice
+
         ci_cd: CI_CD
-        devenv_setup_time: str
+        devenv: DevEnv
 
     class Nix(BaseModel):
         familiarity: NixFamiliarity
-        has_dev_env: Choice
 
     name: str
     author: Author
@@ -167,11 +170,13 @@ def project_from_response(
                 "build_failure_duration": resp.build_failure_duration,
                 "dependency_update": resp.automatic_dependency_update,
             },
-            "devenv_setup_time": resp.devenv_setup_time,
+            "devenv": {
+                "setup_time": resp.devenv_setup_time,
+                "with_nix": resp.nix_dev_env,
+            },
         },
         "nix": {
             "familiarity": resp.nix_familiarity,
-            "has_dev_env": resp.nix_dev_env,
         },
     }
 

--- a/admin/scripts/common/models/__init__.py
+++ b/admin/scripts/common/models/__init__.py
@@ -201,37 +201,35 @@ def project_from_response(
     if resp.contributors is None:
         return (None, "contributors")
 
-    project_dict = {
-        "name": resp.project_name,
-        "author": {
-            "name": resp.author_name,
-            "role": resp.author_role,
-            "contact": {
-                "preferred_channels": resp.author_preferred_channels,
-                "info": resp.author_contact,
-            },
-        },
-        "contributors": resp.contributors,
-        "infra": {
-            "ci_cd": {
-                "build_failure_duration": resp.duration_build_failure,
-                "dependency_update": resp.dependency_update_automatic,
-                "with_nix": resp.nix_ci_cd,
-            },
-            "devenv": {
-                "setup_time": resp.devenv_setup_time,
-                "with_nix": resp.nix_dev_env,
-            },
-        },
-        "nix": {
-            "familiarity": resp.nix_familiarity,
-            "can_ease_onboarding": resp.nix_onboard,
-            "can_help_maintainability": resp.nix_maintain,
-            "can_help_discoverability": resp.nix_discover,
-            "available_for_pairing": resp.nix_pairing,
-        },
-    }
-
-    project = Project.model_validate(project_dict)
+    project = Project(
+        name=resp.project_name,
+        author=Project.Author(
+            name=resp.author_name,
+            role=resp.author_role,
+            contact=Project.Author.ContactInfo(
+                preferred_channels=resp.author_preferred_channels,
+                info=resp.author_contact,
+            ),
+        ),
+        contributors=resp.contributors,
+        infra=Project.Infrastructure(
+            ci_cd=Project.Infrastructure.CI_CD(
+                build_failure_duration=resp.duration_build_failure,
+                dependency_update=resp.dependency_update_automatic,
+                with_nix=resp.nix_ci_cd,
+            ),
+            devenv=Project.Infrastructure.DevEnv(
+                setup_time=resp.devenv_setup_time,
+                with_nix=resp.nix_dev_env,
+            ),
+        ),
+        nix=Project.Nix(
+            familiarity=resp.nix_familiarity,
+            can_ease_onboarding=resp.nix_onboard,
+            can_help_maintainability=resp.nix_maintain,
+            can_help_discoverability=resp.nix_discover,
+            available_for_pairing=resp.nix_pairing,
+        ),
+    )
 
     return (project, "")

--- a/admin/scripts/common/models/__init__.py
+++ b/admin/scripts/common/models/__init__.py
@@ -22,7 +22,7 @@ class ChoiceReminder(str, Enum):
     YES_ONE_MONTH = "Yes, in one month"
 
 
-class ProjectRole(str, Enum):
+class AuthorRole(str, Enum):
     PRINCIPAL_AUTHOR_LEAD_ENGINEER = "Principal author / lead engineer"
     CORE_CONTRIBUTOR_MAINTAINER = "Core contributor / maintainer"
     RELEASE_MANAGER = "Release manager"
@@ -81,7 +81,7 @@ class Form(BaseModel):
 
         time: str = Field(alias="_time")
         author_name: str = Field(alias="_name")
-        author_role: ProjectRole | list[ProjectRole]
+        author_role: list[AuthorRole]
         project_name: str
         build_failure_duration: str
         automatic_dependency_update: Choice
@@ -97,7 +97,7 @@ class Form(BaseModel):
 class Project(BaseModel):
     class Author(BaseModel):
         author_name: str
-        role: ProjectRole | list[ProjectRole]
+        role: list[AuthorRole]
 
     class CI_CD(BaseModel):
         build_failure_duration: str

--- a/admin/scripts/common/models/__init__.py
+++ b/admin/scripts/common/models/__init__.py
@@ -115,3 +115,24 @@ class Project(BaseModel):
     author: Author
     contributors: int
     infra: Infrastructure
+
+
+def project_from_response(
+    resp: Form.Response,
+) -> tuple[Project | None, str]:
+    if resp.contributors is None:
+        return (None, "contributors")
+
+    project = Project(
+        name=resp.project_name,
+        author=Project.Author(author_name=resp.author_name, role=resp.author_role),
+        contributors=resp.contributors,
+        infra=Project.Infrastructure(
+            ci_cd=Project.Infrastructure.CI_CD(
+                build_failure_duration=resp.build_failure_duration,
+                dependency_update=resp.automatic_dependency_update,
+            )
+        ),
+    )
+
+    return (project, "")

--- a/admin/scripts/common/models/__init__.py
+++ b/admin/scripts/common/models/__init__.py
@@ -42,6 +42,10 @@ class UpdateFrequency(str, Enum):
     less_once_per_year = "Less than once per year"
 
 
+# NOTE:
+# This is a bidirectional mapping between the questions and the data fields,
+# which not only makes it possible to access one from another, but also makes
+# setting field aliases much cleaner.
 question_alias_mapping = {
     "q1": "project_name",
     "q2": "author_role",

--- a/admin/scripts/common/models/__init__.py
+++ b/admin/scripts/common/models/__init__.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Optional
+from typing import Optional, Sequence
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -182,8 +182,8 @@ class Project(BaseModel):
                 feedback: str
 
             name: str
-            role: list[str]
-            contact_channels: list[str]
+            role: Sequence[str]
+            contact_channels: Sequence[str]
             contact: str
             available_for_pairing: str
             nix_familiarity: str

--- a/admin/scripts/common/models/__init__.py
+++ b/admin/scripts/common/models/__init__.py
@@ -83,6 +83,10 @@ alias_mapping = {
     "q8": "nix_familiarity",
     "q9": "nix_dev_env",
     "q10": "nix_ci_cd",
+    # longevity
+    "q11": "duration_stable_release",
+    "q12": "duration_future_maintenance",
+    # nix
     "q13": "nix_onboard",
     "q14": "nix_maintain",
     "q15": "nix_discover",
@@ -91,9 +95,36 @@ alias_mapping = {
     "q18": "nix_adoption",
     "q19": "nix_retention",
     "q20": "nix_other_uses",
+    "q21": "nix_pairing",
+    # author
+    "q22": "author_preferred_channels",
+    "q23": "author_contact",
+    #
     "q24": "structured_data_provided",
     "q25": "reminder",
-    "q36": "has_extensions",
+    # artefacts
+    "q26": "libraries_exist",
+    "q27": "documentation_libraries",
+    "q28": "programs_cli",
+    "q29": "programs_gui",
+    "q30": "documentation_programs",
+    "q31": "mobile_apps",
+    "q32": "services",
+    "q33": "documentation_services",
+    "q34": "specification_document",
+    "q35": "personal_deployment",
+    "q36": "extensions_exist",
+    # nixos
+    "q37": "nixos_artefacts",
+    "q38": "nixos_package_name",  # or service
+    "q39": "nixos_maintainer",
+    "q40": "documentation_nixos",
+    #
+    "q41": "documentation_source",
+    "q42": "respository",
+    "q43": "dependency_management",
+    "q44": "framework",
+    "q45": "survey_feedback",
 }
 
 
@@ -139,7 +170,7 @@ class Form(BaseModel):
         nix_discover: ChoiceAgreement
 
         structured_data_provided: bool = Field(default=False)
-        has_extensions: bool = Field(default=False)
+        extensions_exist: bool = Field(default=False)
 
     questions: dict[str, str]
     responses: list[Response]

--- a/admin/scripts/common/models/__init__.py
+++ b/admin/scripts/common/models/__init__.py
@@ -80,6 +80,15 @@ class ContactChannel(str, Enum):
     OTHER = "Other"
 
 
+class ReleasePeriod(str, Enum):
+    NO_YEAR = "There are no stable releases yet"
+    UNDER_1_YEAR = "<1 year"
+    OVER_1_YEAR = ">1 year"
+    OVER_5_YEAR = ">5 years"
+    OVER_10_YEAR = ">10 years"
+    OVER_20_YEAR = ">20 years"
+
+
 class Form(BaseModel):
     class Response(BaseModel):
         @field_validator(
@@ -114,8 +123,8 @@ class Form(BaseModel):
         author_contact: str = Field(alias="q23")
 
         # longevity
-        duration_stable_release: str = Field(alias="q11")
-        duration_future_maintenance: str = Field(alias="q12")
+        duration_stable_release: ReleasePeriod = Field(alias="q11")
+        duration_future_maintenance: ReleasePeriod = Field(alias="q12")
 
         # infra
         duration_build_failure: str = Field(alias="q3")
@@ -183,6 +192,8 @@ class Project(BaseModel):
         repository: str
         contributors: int
         author: Author
+        stable_release_start: str
+        expected_longevity: str
 
     class Infrastructure(BaseModel):
         class CI_CD(BaseModel):
@@ -231,6 +242,8 @@ def project_from_response(
                     reminder=resp.survey_reminder,
                 ),
             ),
+            stable_release_start=resp.duration_stable_release,
+            expected_longevity=resp.duration_future_maintenance,
         ),
         infra=Project.Infrastructure(
             ci_cd=Project.Infrastructure.CI_CD(

--- a/admin/scripts/common/models/__init__.py
+++ b/admin/scripts/common/models/__init__.py
@@ -34,10 +34,10 @@ class ProjectRole(str, Enum):
 
 
 question_alias_mapping = {
-    "q1": "name",
-    "q2": "role",
+    "q1": "project_name",
+    "q2": "author_role",
     "q3": "build_failure_duration",
-    "q4": "dependency_update",
+    "q4": "has_dependency_update",
     "q6": "contributors",
     "q24": "structured_data_provided",
     "q25": "reminder",
@@ -61,10 +61,10 @@ class Form(BaseModel):
 
         time: str = Field(alias="_time")
         author_name: str = Field(alias="_name")
-        name: str
-        role: ProjectRole | list[ProjectRole]
+        author_role: ProjectRole | list[ProjectRole]
+        project_name: str
         build_failure_duration: str
-        dependency_update: Choice
+        has_dependency_update: Choice
         contributors: str
         structured_data_provided: bool = Field(default=False)
         reminder: Optional[ChoiceReminder] = Field(default=None)

--- a/admin/scripts/common/models/__init__.py
+++ b/admin/scripts/common/models/__init__.py
@@ -1,0 +1,64 @@
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class Choice(str, Enum):
+    yes = "Yes"
+    not_planned = "Not planned"
+    not_yet = "Not yet"
+
+
+class Choice2(str, Enum):
+    yes = "Yes"
+    not_sure_yet = "Not sure yet"
+    no = "No"
+
+
+class ChoiceReminder(str, Enum):
+    no = "No"
+    yes_one_week = "Yes, in one week"
+    yes_one_month = "Yes, in one month"
+
+
+class ProjectRole(str, Enum):
+    principal_author_lead_engineer = "Principal author / lead engineer"
+    core_contributor_maintainer = "Core contributor / maintainer"
+    release_manager = "Release manager"
+    security = "Security"
+    infrastructure_devops = "Infrastructure/DevOps"
+    community_manager = "Community manager"
+    outreach_coordinator = "Outreach coordinator"
+    other = "Other"
+
+
+class Form(BaseModel):
+    class Response(BaseModel):
+        time: str = Field(alias="_time")
+        author_name: str = Field(alias="_name")
+        name: str = Field(alias="q1")
+        role: ProjectRole | list[ProjectRole] = Field(alias="q2")
+        build_failure_duration: str = Field(alias="q3")
+        dependency_update: Choice = Field(alias="q4")
+        contributors: str = Field(alias="q6")
+        q24: Optional[Choice2] = Field(alias="q24", default=None)
+        reminder: Optional[ChoiceReminder] = Field(alias="q25", default=None)
+
+    questions: dict[str, str]
+    responses: list[Response]
+
+
+class Project(BaseModel):
+    class Author(BaseModel):
+        author_name: str
+        role: ProjectRole | list[ProjectRole]
+
+    class CI_CD(BaseModel):
+        build_failure_duration: str
+        dependency_update: Choice
+
+    name: str
+    author: Author
+    contributors: str
+    build_system: CI_CD

--- a/admin/scripts/common/models/__init__.py
+++ b/admin/scripts/common/models/__init__.py
@@ -33,11 +33,21 @@ class ProjectRole(str, Enum):
     other = "Other"
 
 
+class UpdateFrequency(str, Enum):
+    cant_say = "Can't say"
+    more_once_per_day = "More than once per day"
+    more_once_per_week = "More than once per week"
+    more_once_per_month = "More than once per month"
+    more_once_per_year = "More than once per year"
+    less_once_per_year = "Less than once per year"
+
+
 question_alias_mapping = {
     "q1": "project_name",
     "q2": "author_role",
     "q3": "build_failure_duration",
-    "q4": "has_dependency_update",
+    "q4": "automatic_dependency_update",
+    "q5": "dependency_update_frequency",
     "q6": "contributors",
     "q24": "structured_data_provided",
     "q25": "reminder",
@@ -59,12 +69,19 @@ class Form(BaseModel):
                 return True
             return False
 
+        @field_validator(question_alias_mapping["q3"], mode="before")
+        def map_duration(cls, value: str) -> str:
+            if value.replace(".", "", 1).isdigit():
+                return f"{value}h per week"
+            return value
+
         time: str = Field(alias="_time")
         author_name: str = Field(alias="_name")
         author_role: ProjectRole | list[ProjectRole]
         project_name: str
         build_failure_duration: str
-        has_dependency_update: Choice
+        automatic_dependency_update: Choice
+        dependency_update_frequency: UpdateFrequency
         contributors: str
         structured_data_provided: bool = Field(default=False)
         reminder: Optional[ChoiceReminder] = Field(default=None)

--- a/admin/scripts/common/models/__init__.py
+++ b/admin/scripts/common/models/__init__.py
@@ -5,41 +5,41 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 class Choice(str, Enum):
-    yes = "Yes"
-    not_planned = "Not planned"
-    not_yet = "Not yet"
+    YES = "Yes"
+    NOT_PLANNED = "Not planned"
+    NOT_YET = "Not yet"
 
 
 class Choice2(str, Enum):
-    yes = "Yes"
-    not_sure_yet = "Not sure yet"
-    no = "No"
+    YES = "Yes"
+    NOT_SURE_YET = "Not sure yet"
+    NO = "No"
 
 
 class ChoiceReminder(str, Enum):
-    no = "No"
-    yes_one_week = "Yes, in one week"
-    yes_one_month = "Yes, in one month"
+    NO = "No"
+    YES_ONE_WEEK = "Yes, in one week"
+    YES_ONE_MONTH = "Yes, in one month"
 
 
 class ProjectRole(str, Enum):
-    principal_author_lead_engineer = "Principal author / lead engineer"
-    core_contributor_maintainer = "Core contributor / maintainer"
-    release_manager = "Release manager"
-    security = "Security"
-    infrastructure_devops = "Infrastructure/DevOps"
-    community_manager = "Community manager"
-    outreach_coordinator = "Outreach coordinator"
-    other = "Other"
+    PRINCIPAL_AUTHOR_LEAD_ENGINEER = "Principal author / lead engineer"
+    CORE_CONTRIBUTOR_MAINTAINER = "Core contributor / maintainer"
+    RELEASE_MANAGER = "Release manager"
+    SECURITY = "Security"
+    INFRASTRUCTURE_DEVOPS = "Infrastructure/DevOps"
+    COMMUNITY_MANAGER = "Community manager"
+    OUTREACH_COORDINATOR = "Outreach coordinator"
+    OTHER = "Other"
 
 
 class UpdateFrequency(str, Enum):
-    cant_say = "Can't say"
-    more_once_per_day = "More than once per day"
-    more_once_per_week = "More than once per week"
-    more_once_per_month = "More than once per month"
-    more_once_per_year = "More than once per year"
-    less_once_per_year = "Less than once per year"
+    CANT_SAY = "Can't say"
+    MORE_ONCE_PER_DAY = "More than once per day"
+    MORE_ONCE_PER_WEEK = "More than once per week"
+    MORE_ONCE_PER_MONTH = "More than once per month"
+    MORE_ONCE_PER_YEAR = "More than once per year"
+    LESS_ONCE_PER_YEAR = "Less than once per year"
 
 
 # NOTE:

--- a/admin/scripts/common/models/__init__.py
+++ b/admin/scripts/common/models/__init__.py
@@ -84,14 +84,16 @@ class Form(BaseModel):
         time: str = Field(alias="_time")
         author_name: str = Field(alias="_name")
         author_role: list[AuthorRole]
+
         project_name: str
         build_failure_duration: str
         automatic_dependency_update: Choice
         dependency_update_frequency: UpdateFrequency
         contributors: int | None
+        reminder: Optional[ChoiceReminder] = Field(default=None)
+
         structured_data_provided: bool = Field(default=False)
         has_extensions: bool = Field(default=False)
-        reminder: Optional[ChoiceReminder] = Field(default=None)
 
     questions: dict[str, str]
     responses: list[Response]
@@ -102,11 +104,14 @@ class Project(BaseModel):
         author_name: str
         role: list[AuthorRole]
 
-    class CI_CD(BaseModel):
-        build_failure_duration: str
-        dependency_update: Choice
+    class Infrastructure(BaseModel):
+        class CI_CD(BaseModel):
+            build_failure_duration: str
+            dependency_update: Choice
+
+        ci_cd: CI_CD
 
     name: str
     author: Author
     contributors: int
-    build_system: CI_CD
+    infra: Infrastructure

--- a/admin/scripts/common/models/__init__.py
+++ b/admin/scripts/common/models/__init__.py
@@ -79,6 +79,12 @@ class Form(BaseModel):
                 return f"{value}h per week"
             return value
 
+        @field_validator(question_alias_mapping["q6"], mode="before")
+        def map_contributors(cls, value: str) -> float | None:
+            if value.replace(".", "", 1).isdigit():
+                return float(value)
+            return None
+
         time: str = Field(alias="_time")
         author_name: str = Field(alias="_name")
         author_role: list[AuthorRole]
@@ -86,7 +92,7 @@ class Form(BaseModel):
         build_failure_duration: str
         automatic_dependency_update: Choice
         dependency_update_frequency: UpdateFrequency
-        contributors: str
+        contributors: int | None
         structured_data_provided: bool = Field(default=False)
         reminder: Optional[ChoiceReminder] = Field(default=None)
 
@@ -105,5 +111,5 @@ class Project(BaseModel):
 
     name: str
     author: Author
-    contributors: str
+    contributors: int
     build_system: CI_CD

--- a/admin/scripts/common/models/__init__.py
+++ b/admin/scripts/common/models/__init__.py
@@ -74,6 +74,7 @@ alias_mapping = {
     "q7": "devenv_setup_time",
     "q8": "nix_familiarity",
     "q9": "nix_dev_env",
+    "q10": "nix_ci_cd",
     "q24": "structured_data_provided",
     "q25": "reminder",
     "q36": "has_extensions",
@@ -116,6 +117,7 @@ class Form(BaseModel):
         # Nix
         nix_familiarity: NixFamiliarity
         nix_dev_env: Choice
+        nix_ci_cd: Choice
 
         structured_data_provided: bool = Field(default=False)
         has_extensions: bool = Field(default=False)
@@ -133,7 +135,7 @@ class Project(BaseModel):
         class CI_CD(BaseModel):
             build_failure_duration: str
             dependency_update: str
-            # with_nix: bool
+            with_nix: Choice
 
         class DevEnv(BaseModel):
             setup_time: str
@@ -169,6 +171,7 @@ def project_from_response(
             "ci_cd": {
                 "build_failure_duration": resp.build_failure_duration,
                 "dependency_update": resp.automatic_dependency_update,
+                "with_nix": resp.nix_ci_cd,
             },
             "devenv": {
                 "setup_time": resp.devenv_setup_time,

--- a/admin/scripts/common/models/__init__.py
+++ b/admin/scripts/common/models/__init__.py
@@ -178,15 +178,15 @@ class Project(BaseModel):
     class Metadata(BaseModel):
         class Author(BaseModel):
             class Survey(BaseModel):
-                reminder: Optional[ChoiceReminder]
+                reminder: Optional[str]
                 feedback: str
 
             name: str
-            role: list[AuthorRole]
-            contact_channels: list[ContactChannel]
+            role: list[str]
+            contact_channels: list[str]
             contact: str
-            available_for_pairing: Choice2
-            nix_familiarity: NixFamiliarity
+            available_for_pairing: str
+            nix_familiarity: str
             survey: Survey
 
         repository: str
@@ -199,19 +199,19 @@ class Project(BaseModel):
         class CI_CD(BaseModel):
             build_failure_duration: str
             dependency_update: str
-            with_nix: Choice
+            with_nix: str
 
         class DevEnv(BaseModel):
             setup_time: str
-            with_nix: Choice
+            with_nix: str
 
         ci_cd: CI_CD
         devenv: DevEnv
 
     class Nix(BaseModel):
-        can_ease_onboarding: ChoiceAgreement
-        can_help_maintainability: ChoiceAgreement
-        can_help_discoverability: ChoiceAgreement
+        can_ease_onboarding: str
+        can_help_maintainability: str
+        can_help_discoverability: str
 
     name: str
     meta: Metadata

--- a/admin/scripts/common/models/__init__.py
+++ b/admin/scripts/common/models/__init__.py
@@ -23,6 +23,14 @@ class ChoiceReminder(str, Enum):
     YES_ONE_MONTH = "Yes, in one month"
 
 
+class ChoiceAgreement(str, Enum):
+    STRONGLY_DISAGREE = "Strongly disagree"
+    DISAGREE = "Disagree"
+    DONT_KNOW = "Don't know/neutral"
+    AGREE = "Agree"
+    STRONGLY_AGREE = "Strongly agree"
+
+
 class AuthorRole(str, Enum):
     PRINCIPAL_AUTHOR_LEAD_ENGINEER = "Principal author / lead engineer"
     CORE_CONTRIBUTOR_MAINTAINER = "Core contributor / maintainer"
@@ -75,6 +83,14 @@ alias_mapping = {
     "q8": "nix_familiarity",
     "q9": "nix_dev_env",
     "q10": "nix_ci_cd",
+    "q13": "nix_onboard",
+    "q14": "nix_maintain",
+    "q15": "nix_discover",
+    "q16": "nix_self_host",
+    "q17": "nix_installation",
+    "q18": "nix_adoption",
+    "q19": "nix_retention",
+    "q20": "nix_other_uses",
     "q24": "structured_data_provided",
     "q25": "reminder",
     "q36": "has_extensions",
@@ -103,10 +119,10 @@ class Form(BaseModel):
             return None
 
         time: str = Field(alias="_time")
+        project_name: str
         author_name: str = Field(alias="_name")
         author_role: list[AuthorRole]
 
-        project_name: str
         build_failure_duration: str
         automatic_dependency_update: Choice
         dependency_update_frequency: UpdateFrequency
@@ -118,6 +134,9 @@ class Form(BaseModel):
         nix_familiarity: NixFamiliarity
         nix_dev_env: Choice
         nix_ci_cd: Choice
+        nix_onboard: ChoiceAgreement
+        nix_maintain: ChoiceAgreement
+        nix_discover: ChoiceAgreement
 
         structured_data_provided: bool = Field(default=False)
         has_extensions: bool = Field(default=False)
@@ -146,6 +165,9 @@ class Project(BaseModel):
 
     class Nix(BaseModel):
         familiarity: NixFamiliarity
+        can_ease_onboarding: ChoiceAgreement
+        can_help_maintainability: ChoiceAgreement
+        can_help_discoverability: ChoiceAgreement
 
     name: str
     author: Author
@@ -180,6 +202,9 @@ def project_from_response(
         },
         "nix": {
             "familiarity": resp.nix_familiarity,
+            "can_ease_onboarding": resp.nix_onboard,
+            "can_help_maintainability": resp.nix_maintain,
+            "can_help_discoverability": resp.nix_discover,
         },
     }
 

--- a/admin/scripts/extract_survey_results.py
+++ b/admin/scripts/extract_survey_results.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python3
+
+import argparse
+import json
+import sys
+
+import ijson
+from common.models import Form, Project
+
+
+class Cli:
+    def __init__(self) -> None:
+        self.parser = argparse.ArgumentParser(
+            description="",
+        )
+
+        self.parser.add_argument(
+            "form_file",
+            type=argparse.FileType("r"),
+            help="",
+        )
+        self.parser.add_argument(
+            "-d",
+            "--debug",
+            action="store_true",
+            help="Print debugging information",
+        )
+
+        if len(sys.argv) == 1:
+            self.parser.print_help()
+            sys.exit(1)
+
+        self.args = self.parser.parse_args()
+
+
+def main():
+    args = Cli().args
+
+    with args.form_file as f:
+        data = ijson.items(f, "")
+        form = Form(**next(data))
+
+    projects = [
+        Project(
+            name=r.name,
+            author=Project.Author(author_name=r.author_name, role=r.role),
+            contributors=r.contributors,
+            build_system=Project.CI_CD(
+                build_failure_duration=r.build_failure_duration,
+                dependency_update=r.dependency_update,
+            ),
+        )
+        for r in form.responses
+    ]
+
+    json.dump([p.model_dump() for p in projects], sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/admin/scripts/extract_survey_results.py
+++ b/admin/scripts/extract_survey_results.py
@@ -47,7 +47,7 @@ def main():
             contributors=r.contributors,
             build_system=Project.CI_CD(
                 build_failure_duration=r.build_failure_duration,
-                dependency_update=r.has_dependency_update,
+                dependency_update=r.automatic_dependency_update,
             ),
         )
         for r in form.responses

--- a/admin/scripts/extract_survey_results.py
+++ b/admin/scripts/extract_survey_results.py
@@ -42,12 +42,12 @@ def main():
 
     projects = [
         Project(
-            name=r.name,
-            author=Project.Author(author_name=r.author_name, role=r.role),
+            name=r.project_name,
+            author=Project.Author(author_name=r.author_name, role=r.author_role),
             contributors=r.contributors,
             build_system=Project.CI_CD(
                 build_failure_duration=r.build_failure_duration,
-                dependency_update=r.dependency_update,
+                dependency_update=r.has_dependency_update,
             ),
         )
         for r in form.responses


### PR DESCRIPTION
You can use [watchexec](https://search.nixos.org/packages?channel=unstable&show=watchexec&from=0&size=50&sort=relevance&type=packages&query=watchexec) to rapidly iterate on this as files change:

```sh
$ cd admin/scripts
$ watchexec 'python extract_survey_results.py survey_responses.json'
```

Closes: https://github.com/ngi-nix/summer-of-nix/issues/150