### PR TITLE
Update link to documentation on Nixpkgs committers

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Additionally, applicants have to:
 ### Mentors
 
 To be considered for the mentor role, in addition to the [requirements for participants](#participants), applicants must have:
-- [Merge access to Nixpkgs](https://github.com/orgs/nixos/teams/nixpkgs-committers).
+- [Merge access to Nixpkgs](https://github.com/NixOS/org/blob/main/doc/nixpkgs-committers.md).
 - Command of at least two widely-used programming languages
 - Firm grasp of software development best practices
 - Excellent control of Git


### PR DESCRIPTION
This pull request updates the Mentors section to include a public link, increasing accessibility for all users and promoting transparency. The previous link, restricted to committers only, limited the section's usefulness and created an unnecessary barrier to entry for potential contributors. By replacing the private link with a public one, we can foster a more inclusive and collaborative community, aligning with the project's values and goals.

closes #187 